### PR TITLE
add wait for the async frontend deployment process

### DIFF
--- a/deployment/package.json
+++ b/deployment/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "aws-cdk": "^2.1031.1"
+    "aws-cdk": "^2.1031.2"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

Solve the frontend deployment asset not finished building issue.

*Description of changes:*

Tested the deployement and verified with login to the UI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
